### PR TITLE
Map drums to osc messages

### DIFF
--- a/Library/LiveCode.ck
+++ b/Library/LiveCode.ck
@@ -41,31 +41,11 @@ for (0 => int i; i < 10; i++) {
 1 => float snareGain;
 1 => float kickGain;
 
-live.join(live.dec2Pos(STATIC.oscSnare[1]),
-          live.dec2Pos(STATIC.oscSnare[2]),
-          live.dec2Pos(STATIC.oscSnare[3]),
-          live.dec2Pos(STATIC.oscSnare[4])) @=> int snareArray[];
-
-live.join(live.dec2Pos(STATIC.oscOpenHats[1]),
-          live.dec2Pos(STATIC.oscOpenHats[2]), 
-          live.dec2Pos(STATIC.oscOpenHats[3]),
-          live.dec2Pos(STATIC.oscOpenHats[4])) @=> int openHatsArray[];
-
-live.join(live.dec2Pos(STATIC.oscSplash[1]),
-          live.dec2Pos(STATIC.oscSplash[2]),
-          live.dec2Pos(STATIC.oscSplash[3]),
-          live.dec2Pos(STATIC.oscSplash[4])) @=> int splashArray[];
-
-live.join(live.dec2Pos(STATIC.oscClosedHats[1]),
-          live.dec2Pos(STATIC.oscClosedHats[2]),
-          live.dec2Pos(STATIC.oscClosedHats[3]),
-          live.dec2Pos(STATIC.oscClosedHats[4])) @=> int closedHatsArray[];
-
-spork~live.play(Buffer.kick, STATIC.kickArray, STATIC.oscKickAmp*kickGain/100.0);
-spork~live.play(Buffer.snare, snareArray, STATIC.oscSnareAmp*snareGain/100.0);
-spork~live.play(Buffer.hatsOpen, openHatsArray, STATIC.oscOpenHatsAmp*hatsGain/100.0, hatsRatio);
-spork~live.play(Buffer.hatsSplash, splashArray, STATIC.oscSplashAmp*hatsGain/100.0, hatsRatio);
-spork~live.play(Buffer.hatsGhost1, closedHatsArray, STATIC.oscClosedHatsAmp*hatsGain/100.0, hatsRatio);
+spork~live.play(Buffer.kick, STATIC.oscKickArray, STATIC.oscKickAmp*kickGain/100.0);
+spork~live.play(Buffer.snare, STATIC.oscSnareArray, STATIC.oscSnareAmp*snareGain/100.0);
+spork~live.play(Buffer.hatsOpen, STATIC.oscOpenHatsArray, STATIC.oscOpenHatsAmp*hatsGain/100.0, hatsRatio);
+spork~live.play(Buffer.hatsSplash, STATIC.oscSplashArray, STATIC.oscSplashAmp*hatsGain/100.0, hatsRatio);
+spork~live.play(Buffer.hatsGhost1, STATIC.oscClosedHatsArray, STATIC.oscClosedHatsAmp*hatsGain/100.0, hatsRatio);
 // spork~live.play(Buffer.hatsGhost2,live.fill([2,6,10,14],divOneBar),STATIC.oscClosedHats[1]*hatsGain/100.0,hatsRatio);
 // spork~live.play(Buffer.hatsGhost3,live.join([3,7,11,15],[3,7,11],divOneBar),STATIC.oscClosedHats[1]*hatsGain/100.0,hatsRatio);
 

--- a/Library/OscRecvr.ck
+++ b/Library/OscRecvr.ck
@@ -39,46 +39,46 @@ while( true )
           msg.getInt(3) => STATIC.oscMaster[3];
         }
 
-        // // Decode the different messages 
+        // Decode the different messages 
         if (msg.address == "/drum/kick") {
           msg.numArgs() +=> STATIC.oscMsgRecvr;
           msg.getInt(0) => STATIC.oscKickAmp;
           live.join(live.dec2Pos(msg.getInt(1)),
                     live.dec2Pos(msg.getInt(2)),
                     live.dec2Pos(msg.getInt(3)),
-                    live.dec2Pos(msg.getInt(4))) @=> STATIC.kickArray;
+                    live.dec2Pos(msg.getInt(4))) @=> STATIC.oscKickArray;
         }  
         if (msg.address == "/drum/snare") {
           msg.numArgs() +=> STATIC.oscMsgRecvr;
           msg.getInt(0) => STATIC.oscSnareAmp;
-          msg.getInt(1) => STATIC.oscSnare[1];
-          msg.getInt(2) => STATIC.oscSnare[2];
-          msg.getInt(3) => STATIC.oscSnare[3];
-          msg.getInt(4) => STATIC.oscSnare[4];
+          live.join(live.dec2Pos(msg.getInt(1)),
+                    live.dec2Pos(msg.getInt(2)),
+                    live.dec2Pos(msg.getInt(3)),
+                    live.dec2Pos(msg.getInt(4))) @=> STATIC.oscSnareArray;   
         }  
         if (msg.address == "/drum/openhats") {
           msg.numArgs() +=> STATIC.oscMsgRecvr;
           msg.getInt(0) => STATIC.oscOpenHatsAmp;
-          msg.getInt(1) => STATIC.oscOpenHats[1];
-          msg.getInt(2) => STATIC.oscOpenHats[2];
-          msg.getInt(3) => STATIC.oscOpenHats[3];
-          msg.getInt(4) => STATIC.oscOpenHats[4];
+          live.join(live.dec2Pos(msg.getInt(1)),
+                    live.dec2Pos(msg.getInt(2)),
+                    live.dec2Pos(msg.getInt(3)),
+                    live.dec2Pos(msg.getInt(4))) @=> STATIC.oscOpenHatsArray;
         }  
         if (msg.address == "/drum/closedhats") {
           msg.numArgs() +=> STATIC.oscMsgRecvr;
           msg.getInt(0) => STATIC.oscClosedHatsAmp;
-          msg.getInt(1) => STATIC.oscClosedHats[1];
-          msg.getInt(2) => STATIC.oscClosedHats[2];
-          msg.getInt(3) => STATIC.oscClosedHats[3];
-          msg.getInt(4) => STATIC.oscClosedHats[4];
+          live.join(live.dec2Pos(msg.getInt(1)),
+                    live.dec2Pos(msg.getInt(2)),
+                    live.dec2Pos(msg.getInt(3)),
+                    live.dec2Pos(msg.getInt(4))) @=> STATIC.oscClosedHatsArray;
         }  
         if (msg.address == "/drum/splash") {
           msg.numArgs() +=> STATIC.oscMsgRecvr;
           msg.getInt(0) => STATIC.oscSplashAmp;
-          msg.getInt(1) => STATIC.oscSplash[1];
-          msg.getInt(2) => STATIC.oscSplash[2];
-          msg.getInt(3) => STATIC.oscSplash[3];
-          msg.getInt(4) => STATIC.oscSplash[4];
+          live.join(live.dec2Pos(msg.getInt(1)),
+                    live.dec2Pos(msg.getInt(2)),
+                    live.dec2Pos(msg.getInt(3)),
+                    live.dec2Pos(msg.getInt(4))) @=> STATIC.oscSplashArray;
         }  
     }     
 }

--- a/Library/STATIC.ck
+++ b/Library/STATIC.ck
@@ -25,15 +25,14 @@ public class STATIC
     // Information transmitted over OSC
     static int oscMaster[8];
     static int oscKickAmp;
-    static int kickArray[16*4];
+    static int oscKickArray[DIVISION*CYCLES];
     static int oscSnareAmp;
-    static int oscSnare[8];
-    static int oscOpenHatsLen;
+    static int oscSnareArray[DIVISION*CYCLES];
     static int oscOpenHatsAmp;
-    static int oscOpenHats[8];
+    static int oscOpenHatsArray[DIVISION*CYCLES];
     static int oscClosedHatsAmp;
-    static int oscClosedHats[8];
+    static int oscClosedHatsArray[DIVISION*CYCLES];
     static int oscSplashAmp;
-    static int oscSplash[8];
+    static int oscSplashArray[DIVISION*CYCLES];
 
 }


### PR DESCRIPTION
Convert all of the drums so that they are decoded in the OscRecvr.ck before then being used within the LiveCode.ck

This minimises any processing within LiveCode.ck this is more time critical